### PR TITLE
Using pr rather than print for non-string objects (by default).

### DIFF
--- a/src/taoensso/timbre.clj
+++ b/src/taoensso/timbre.clj
@@ -10,10 +10,11 @@
 ;;;; Public utils
 
 (defn str-println
-  "Like `println` but prints all objects to output stream as a single
-  atomic string. This is faster and avoids interleaving race conditions."
+  "Like `prn` but prints all objects to output stream as a single atomic
+  string. Strings are printed with print, other objects are printed with
+  pr. This is faster and avoids interleaving race conditions. "
   [& xs]
-  (print (str/join \space (filter identity xs)) \newline)
+  (print (str/join \space (map #(if (string? %) % (with-out-str pr %)) xs)) \newline)
   (flush))
 
 (defn color-str [color & xs]


### PR DESCRIPTION
Hi Peter,

This request came from one of my clients who is logging data-structures and would like to be able to log them in a form he can read back in (during REPL development) without having to do so much hand-editing. By using pr rather than print, you get the following :-

INFO The map was {:status 2 :message "Hello"}

rather than 

INFO The map was {:status 2 :message Hello}

This might be something that is better done via switchable config. Some people like to use 'logs as data' and make it easier for a machine to read the data back in.

Regards,

Malcolm
