### PR TITLE
Remove an eastwood warning in defnp macro

### DIFF
--- a/src/taoensso/timbre/profiling.clj
+++ b/src/taoensso/timbre/profiling.clj
@@ -134,7 +134,7 @@
   (let [[name [params & sigs]] (encore/name-with-attrs name sigs)
         prepost-map (when (and (map? (first sigs)) (next sigs)) (first sigs))
         body (if prepost-map (next sigs) sigs)]
-    `(defn ~name ~params ~prepost-map
+    `(defn ~name ~params ~(or prepost-map {})
        (pspy ~(clojure.core/name name)
              ~@body))))
 


### PR DESCRIPTION
Remove an [eastwood](https://github.com/jonase/eastwood) warning by turning pre/post map into an empty map if it is nil for the defnp macro.
