### PR TITLE
Latest version number in Getting Started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Logging with Java can be maddeningly, unnecessarily hard. Particularly if all yo
 Add the necessary dependency to your [Leiningen][] `project.clj` and use the supplied ns-import helper:
 
 ```clojure
-[com.taoensso/timbre "3.2.0"] ; project.clj
+[com.taoensso/timbre "3.2.1"] ; project.clj
 
 (ns my-app (:require [taoensso.timbre :as timbre])) ; Your ns
 (timbre/refer-timbre) ; Provides useful Timbre aliases in this ns


### PR DESCRIPTION
This has bitten me with a 
Exception in thread "main" java.lang.ExceptionInInitializerError
    at clojure.main.<clinit>(main.java:20)
Caused by: java.io.FileNotFoundException: Could not locate clojure/tools/reader/edn__init.class or clojure/tools/reader/edn.clj on classpath: , compiling:(taoensso/encore.clj:1:1)
