### PR TITLE
ZeroMQ appender for timbre.

### DIFF
--- a/src/taoensso/timbre/appenders/zmq.clj
+++ b/src/taoensso/timbre/appenders/zmq.clj
@@ -24,7 +24,7 @@
   [& [appender-opts {:keys [transport address port]}]]
   (let [default-appender-opts {:enabled? true
                                :min-level :error
-                               :async? false}
+                               :async? true}
         context (zmq/zcontext)
         socket (make-zmq-socket context transport address port)
         poller (doto (zmq/poller context)


### PR DESCRIPTION
This is an appender that publishes logged messages to a ZeroMQ socket.
