### PR TITLE
Make times in nanosecs also be formatted

### DIFF
--- a/src/taoensso/timbre/profiling.clj
+++ b/src/taoensso/timbre/profiling.clj
@@ -199,7 +199,7 @@
                (cond (ok-pow? 9) (str (to-pow 9 1) "s")
                      (ok-pow? 6) (str (to-pow 6 0) "ms")
                      (ok-pow? 3) (str (to-pow 3 0) "μs")
-                     :else       (str nanosecs     "ns"))))]
+                     :else       (str (to-pow 0 0) "ns"))))]
 
     (with-out-str
       (printf s-pattern "Id" "nCalls" "Min" "Max" "MAD" "Mean" "Time%" "Time")


### PR DESCRIPTION
Times in nanosecs were previously not converted to double, so they were printed as a fraction, like 32475509/125000, which is not very convenient to read and compare to other values.
I tested this with the high-n example in profiling.clj.
