### PR TITLE
Update Android appender to 3.x API

### DIFF
--- a/src/taoensso/timbre/appenders/android.clj
+++ b/src/taoensso/timbre/appenders/android.clj
@@ -2,32 +2,40 @@
   "Android LogCat appender. Depends on the android runtime. This is a
   configuration for the timbre logging library"
   {:author "Adam Clements"}
-  (:require [taoensso.timbre :as timbre]))
+  (:require [taoensso.timbre :as timbre]
+            clojure.string))
+
+(defn make-logcat-appender
+  "Returns an appender that writes to Android LogCat. Obviously only works if
+  running within the Android runtime (device or emulator). You may want to
+  disable std-out to prevent printing nested timestamps, etc."
+  [& [appender-opts make-opts]]
+  (let [default-appender-opts {:enabled? true
+                               :min-level :debug}]
+    (merge default-appender-opts appender-opts
+           {:fn (fn [{:keys [level ns throwable message]}]
+                  (let [output (format "%s %s - %s" timestamp
+                                       (-> level name clojure.string/upper-case)
+                                       (or message ""))]
+                    (if throwable
+                      (case level
+                        :trace  (android.util.Log/d ns output throwable)
+                        :debug  (android.util.Log/d ns output throwable)
+                        :info   (android.util.Log/i ns output throwable)
+                        :warn   (android.util.Log/w ns output throwable)
+                        :error  (android.util.Log/e ns output throwable)
+                        :fatal  (android.util.Log/e ns output throwable)
+                        :report (android.util.Log/i ns output throwable))
+
+                      (case level
+                        :trace  (android.util.Log/d ns output)
+                        :debug  (android.util.Log/d ns output)
+                        :info   (android.util.Log/i ns output)
+                        :warn   (android.util.Log/w ns output)
+                        :error  (android.util.Log/e ns output)
+                        :fatal  (android.util.Log/e ns output)
+                        :report (android.util.Log/i ns output)))))})))
 
 (def logcat-appender
-  {:doc (str "Appends to Android logcat. Obviously only works if "
-             "running within the Android runtime (device or emulator)."
-             "You may want to disable std-out to prevent printing nested "
-             "timestamps, etc.")
-   :min-level :debug
-   :enabled? true
-   :prefix-fn :ns
-   :fn (fn [{:keys [level prefix throwable message]}]
-         (if throwable
-           (case level
-             :trace  (android.util.Log/d prefix message throwable)
-             :debug  (android.util.Log/d prefix message throwable)
-             :info   (android.util.Log/i prefix message throwable)
-             :warn   (android.util.Log/w prefix message throwable)
-             :error  (android.util.Log/e prefix message throwable)
-             :fatal  (android.util.Log/e prefix message throwable)
-             :report (android.util.Log/i prefix message throwable))
-
-           (case level
-             :trace  (android.util.Log/d prefix message)
-             :debug  (android.util.Log/d prefix message)
-             :info   (android.util.Log/i prefix message)
-             :warn   (android.util.Log/w prefix message)
-             :error  (android.util.Log/e prefix message)
-             :fatal  (android.util.Log/e prefix message)
-             :report (android.util.Log/i prefix message))))})
+  "DEPRECATED: Use `make-logcat-appender` instead."
+  (make-logcat-appender))


### PR DESCRIPTION
As requested in #41.

Sidenote: I still had to fork Timbre for my Android work. Unfortunately `io.aviso.exception` that Timbre uses relies on `clojure.core/bean` function that uses java.beans API. That API doesn't exist in the Android runtime. In debug build of my project I was able to get away with it by overriding `:fmt-output-fn` (so that Timbre's `stacktrace` functions is not called), but in release build (where I AOT only necessary namespaces) the runtime fails at loading `io.aviso.exception`. I'm not sure why the latter happens, and I'm quite reluctant to investigate.

So, I guess there isn't a good way to make `io.aviso/pretty` an optional dependency while at the same time requiring regular users to do extra actions. I'm fine using a fork, but if you have any ideas about it I'd love to hear them.