### PR TITLE
Readme note about shutdown agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,17 @@ java.lang.Exception: Oh noes
           <...>
 ```
 
-Timbre makes use of futures so that logging does not block your application. This will create a new Clojure thread pool which needs to be shutdown via a call to `(shutdown-agents)` when you are done logging. This is a bug in Clojure and can be tracked [here](http://dev.clojure.org/jira/browse/CLJ-124).
+Timbre makes use of futures so that logging does not block your application. This will create a new Clojure thread pool which needs to be shutdown via a call to `(shutdown-agents)` when you are done logging: 
+
+```clojure
+(defn -main [& args]
+  (try
+    ;; make use of timbre here
+    (finally
+      (shutdown-agents))))
+```
+
+This is a bug in Clojure and can be tracked [here](http://dev.clojure.org/jira/browse/CLJ-124)
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ java.lang.Exception: Oh noes
           <...>
 ```
 
+Timbre makes use of futures so that logging does not block your application. This will create a new Clojure thread pool which needs to be shutdown via a call to `(shutdown-agents)` when you are done logging. This is a bug in Clojure and can be tracked [http://dev.clojure.org/jira/browse/CLJ-124](here).
+
 ### Configuration
 
 This is the biggest win over Java logging utilities IMO. Here's `timbre/example-config` (also Timbre's default config):

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ java.lang.Exception: Oh noes
           <...>
 ```
 
-Timbre makes use of futures so that logging does not block your application. This will create a new Clojure thread pool which needs to be shutdown via a call to `(shutdown-agents)` when you are done logging. This is a bug in Clojure and can be tracked [http://dev.clojure.org/jira/browse/CLJ-124](here).
+Timbre makes use of futures so that logging does not block your application. This will create a new Clojure thread pool which needs to be shutdown via a call to `(shutdown-agents)` when you are done logging. This is a bug in Clojure and can be tracked [here](http://dev.clojure.org/jira/browse/CLJ-124).
 
 ### Configuration
 


### PR DESCRIPTION
Ran into issue #61 when using Timbre for the first time yesterday. I don't think this is something Timbre can solve, but I do think this is something Timbre should make its users aware of.

Added a little note to the README so that potential users are aware of the need to call `(shutdown-agents)` unit this is resolved in Clojure itself.