### PR TITLE
Added test for rotating log appender.

### DIFF
--- a/src/taoensso/timbre/appenders/3rd_party/rotor.clj
+++ b/src/taoensso/timbre/appenders/3rd_party/rotor.clj
@@ -4,8 +4,6 @@
             [taoensso.timbre :as timbre])
   (:import  [java.io File FilenameFilter]))
 
-;; TODO Test port to Timbre v4
-
 (defn- ^FilenameFilter file-filter
   "Returns a Java FilenameFilter instance which only matches
   files with the given `basename`."
@@ -50,7 +48,7 @@
   [& [{:keys [path max-size backlog]
        :or   {path     "./timbre-rotor.log"
               max-size (* 1024 1024)
-              backlog  5}}]]
+              backlog  5} :as args}]]
   {:enabled?   true
    :async?     false
    :min-level  nil

--- a/src/taoensso/timbre/appenders/3rd_party/rotor.clj
+++ b/src/taoensso/timbre/appenders/3rd_party/rotor.clj
@@ -48,7 +48,7 @@
   [& [{:keys [path max-size backlog]
        :or   {path     "./timbre-rotor.log"
               max-size (* 1024 1024)
-              backlog  5} :as args}]]
+              backlog  5}}]]
   {:enabled?   true
    :async?     false
    :min-level  nil

--- a/test/taoensso/timbre/appenders/3rd_party/rotor_test.clj
+++ b/test/taoensso/timbre/appenders/3rd_party/rotor_test.clj
@@ -1,0 +1,29 @@
+(ns taoensso.timbre.appenders.3rd-party.rotor-test
+  (:require
+    [clojure.test :refer :all]
+    [clojure.java.io :as io]
+    [taoensso.timbre :as timbre]
+            [taoensso.timbre.appenders.3rd-party.rotor :as rotor]))
+
+(deftest rotor-test
+  []
+  (let [logfile "rotor-test.log"
+        n-logs 5]
+    (timbre/merge-config!
+      {:appenders {:rotor (rotor/rotor-appender
+                            {:path logfile
+                             :max-size 200
+                             :backlog n-logs})}})
+    (doseq [i (range 100)]
+      (timbre/info "testing..."))
+
+    (let [f (io/file logfile)]
+      (is (.exists f))
+      (.delete f))
+
+    (doseq [i (range 1 (inc n-logs))]
+      (let [f (io/file (str logfile ".00" i))]
+        (is (.exists f))
+        (.delete f)))))
+
+


### PR DESCRIPTION
I noticed the TODO line at the top of the rotor appender, and before upgrading Onyx to use the latest timbre I wanted to verify that it indeed worked correctly.  This simple unit test verifies that at least the logs are created and rolled according to the settings.

Thanks for saving us from Java logging hell! :-)