### PR TITLE
Allow args to swap-config! function

### DIFF
--- a/src/taoensso/timbre.cljx
+++ b/src/taoensso/timbre.cljx
@@ -131,9 +131,9 @@
 (defmacro with-merged-config [config & body]
   `(binding [*config* (enc/nested-merge *config* ~config)] ~@body))
 
-(defn swap-config! [f]
-  #+cljs (set!             *config* (f *config*))
-  #+clj  (alter-var-root #'*config*  f))
+(defn swap-config! [f & args]
+  #+cljs (set!                   *config* (apply f *config* args))
+  #+clj  (apply alter-var-root #'*config* f args))
 
 (defn   set-config! [m] (swap-config! (fn [_old] m)))
 (defn merge-config! [m] (swap-config! (fn [old] (enc/nested-merge old m))))


### PR DESCRIPTION
This is so trivial it's a bit silly, but this PR allows `swap-config!` to be passed arguments, following the pattern of `clojure.core` functions such as `swap!`, `alter-var-root`, `update` etc.

The end result is you can write code like this:

```clojure
(timbre/swap-config! assoc-in [:appenders :println :enabled?] false)
```

rather than:

```clojure
(timbre/swap-config! #(assoc-in % [:appenders :println :enabled?] false))
```

There aren't any tests for this namespace so I haven't added any for this change, but I've manually tested the function (despite it being very simple) in both Clojure and Clojurescript.