### PR TITLE
update encore dependency version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [com.taoensso/timbre "4.1.4"] ; Stable, see CHANGELOG for details
 ```
 
-# Timbre, a (sane) Clojure/Script logging & profiling library
+# Timbre, a pure Clojure/Script logging library
 
 Java logging is a mess of complexity that buys you _nothing_. It can be comically hard to get even the simplest logging working, and it's no better at scale.
 

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject com.taoensso/timbre "4.1.4"
+(defproject com.taoensso/timbre "4.2.0-SNAPSHOT"
   :author "Peter Taoussanis <https://www.taoensso.com>"
-  :description "Clojure/Script logging & profiling library"
+  :description "Pure Clojure/Script logging library"
   :url "https://github.com/ptaoussanis/timbre"
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
 
   :dependencies
   [[org.clojure/clojure "1.5.1"]
-   [com.taoensso/encore "2.29.0"]
+   [com.taoensso/encore "2.29.1"]
    [io.aviso/pretty     "0.1.20"]]
 
   :plugins


### PR DESCRIPTION
Minimum version in `src/taoensso.timbre.cljx` appears to be 2.29.1