### PR TITLE
Allow compile-time log level to be set with system property

### DIFF
--- a/src/taoensso/timbre.cljx
+++ b/src/taoensso/timbre.cljx
@@ -160,7 +160,7 @@
 
 (comment (qb 10000 (level>= :info :debug)))
 
-#+clj (defn- env-val [id] (when-let [s (System/getenv id)] (enc/read-edn s)))
+#+clj (defn- env-val [id] (when-let [s (or (System/getProperty id) (System/getenv id))] (enc/read-edn s)))
 #+clj (def ^:private compile-time-level
         (have [:or nil? valid-level]
           (keyword (or (env-val "TIMBRE_LEVEL")


### PR DESCRIPTION
This is useful since it allows one to dynamically set the log level prior to ClojureScript compilation. Specifically, I would like to use this inside of a Boot task.