### PR TITLE
Update example-config in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ This is the biggest win over Java logging IMO. Here's `timbre/example-config` (a
       :level           ; Keyword
       :error-level?    ; Is level e/o #{:error :fatal}?
       :?ns-str         ; String, or nil
-      :?file           ; String, or nil  ; Waiting on CLJ-865
+      :?file           ; String, or nil
       :?line           ; Integer, or nil ; Waiting on CLJ-865
 
       :?err_           ; Delay - first-arg platform error, or nil
@@ -170,18 +170,9 @@ This is the biggest win over Java logging IMO. Here's `timbre/example-config` (a
    :output-fn default-output-fn ; (fn [data]) -> string
 
    :appenders
-   {:example-println-appender ; Appender id
-     ;; Appender definition (just a map):
-     {:enabled?   true
-      :async?     false
-      :min-level  nil
-      :rate-limit [[1 250] [10 5000]] ; 1/250ms, 10/5s
-      :output-fn  :inherit
-      :fn ; Appender's fn
-      (fn [data]
-        (let [{:keys [output-fn]} data
-              formatted-output-str (output-fn data)]
-          (println formatted-output-str)))}}})
+   {:println (println-appender) ; Default Clj appender (see source for options)
+    :console (console-appender) ; Default Cljs appender (see source for options)
+    }})
 ```
 
 A few things to note:


### PR DESCRIPTION
The appender name `:example-println-appender` was a bit confusing and I had to
dig into the source code to find out the default name was `:println`

I also noticed some of the options in the Readme were different from the
defaults in the code (`:rate-limit`, for example) and the Readme states the config
shown is "Timbre's default config"

This pull request reproduces exactly what is in the source code at this moment,
at the expense of removing some useful options from the example. Maybe those
could be added as a separate example in the Readme?