### PR TITLE
Allows disabling ANSI colours w/ env var

### DIFF
--- a/src/taoensso/timbre.cljx
+++ b/src/taoensso/timbre.cljx
@@ -112,7 +112,9 @@
    #+clj :timestamp-opts
    #+clj default-timestamp-opts ; {:pattern _ :locale _ :timezone _}
 
-   :output-fn default-output-fn ; (fn [data]) -> string
+   ; (fn [data]) -> string
+   :output-fn #(let [env (System/getenv "TIMBRE_NO_STACKTRACE_FONTS")]
+                (default-output-fn (if env {:stacktrace-fonts {}}) %))
 
    :appenders
    #+clj


### PR DESCRIPTION
When reading `timbre` logs from files, stack traces include non-printable characters for the ANSI colour characters. This can become annoying after reading logs for a while.

While it is possible to disable ANSI colours in stack traces using ` (merge-config! {:output-fn (partial default-output-fn {:stacktrace-fonts {}})})`, including this in every app entry point is not ideal for people like me who believe colours in stack traces should be disabled by default. No colours in logs by default could be ideal for production systems, i.e..

The changes here disable stack trace fonts when the environment variable `TIMBRE_NO_STACKTRACE_FONTS` is set. This doesn't break the previous behaviour of the library.