### PR TITLE
Fix the 3rd party logstash appender

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
      [com.taoensso/carmine    "2.13.1"]
      [com.draines/postal      "2.0.0"]
      [irclj                   "0.5.0-alpha4"]
-     [org.graylog2/gelfclient "1.4.0"]
+     [org.graylog2/gelfclient "1.4.0" :exclusions [com.fasterxml.jackson.core/jackson-core]]
      [org.julienxx/clj-slack  "0.5.4"]
      [org.clojure/java.jdbc   "0.6.1"]
      [com.mchange/c3p0        "0.9.5.2"]


### PR DESCRIPTION
Gelfclient uses an older version of JacksonXML which prevents the logstash appender from loading.  I've tested this fix with logstash and my logs arrive.  I'm not sure how to test the GELF functionality so have not tested how this change affects that.

Thanks for a great logging library!