### PR TITLE
rolling appender - creating parent directories when they don't exist

### DIFF
--- a/src/taoensso/timbre/appenders/3rd_party/rolling.clj
+++ b/src/taoensso/timbre/appenders/3rd_party/rolling.clj
@@ -61,6 +61,8 @@
            prev-cal   (prev-period-end-cal instant pattern)]
        (when-let [log (io/file path)]
          (try
+           (when-not (.exists log)
+             (io/make-parents log))
            (if (.exists log)
              (if (<= (.lastModified log) (.getTimeInMillis prev-cal))
                (shift-log-period log path prev-cal))


### PR DESCRIPTION
I noticed the rolling file appender doesn't create parent directories if they don't exist so I added that in.