### PR TITLE
log first two elements of LazySeq objects

### DIFF
--- a/src/taoensso/timbre.cljx
+++ b/src/taoensso/timbre.cljx
@@ -253,10 +253,19 @@
         (fn [x]
           (let [x (enc/nil->str x)] ; Undefined, nil -> "nil"
             (cond
-              (record?          x) (pr-str x)
-              ;; (enc/lazy-seq? x) (pr-str x) ; Dubious?
-              :else x))))
-      xs))
+              (record? x)
+              (pr-str x)
+
+              (enc/lazy-seq? x)
+              (let [first-two (seq (take 2 x))
+                    more? (seq (drop 2 x))]
+                    (if more?
+                      (into '(…) (reverse first-two))
+                      first-two))
+
+              :else
+              x))))
+    xs))
   (defn- str-join [xs] (str/join " " #+clj xs #+cljs (filter identity xs))))
 
 (comment


### PR DESCRIPTION
I regularly wish timbre logged at least partial contents of a `clojure.lang.LazySeq` rather than something like `clojure.lang.LazySeq@7861`. 

I see that you've at least considered the idea here:
https://github.com/ptaoussanis/timbre/blob/master/src/taoensso/timbre.cljx#L257

Are you interested in adding something like this that at least logs a couple items in the sequence?

This is what this patch prints out when it comes across a LazySeq:

```
user=> (taoensso.timbre/info (map identity [1 2]))
16-10-26 22:08:16 ryans-mbp INFO [user:1] - (1 2)
nil
user=> (taoensso.timbre/info (map identity [1 2 3]))
16-10-26 22:08:19 ryans-mbp INFO [user:1] - (1 2 …)
```
