### PR TITLE
Add :append param to spit-appender to allow clobber behavior

### DIFF
--- a/src/taoensso/timbre/appenders/core.cljx
+++ b/src/taoensso/timbre/appenders/core.cljx
@@ -70,7 +70,7 @@
 #+clj
 (defn spit-appender
   "Returns a simple `spit` file appender for Clojure."
-  [& [{:keys [fname] :or {fname "./timbre-spit.log"}}]]
+  [& [{:keys [fname append] :or {fname "./timbre-spit.log" append true}}]]
   {:enabled?   true
    :async?     false
    :min-level  nil
@@ -80,7 +80,7 @@
    (fn self [data]
      (let [{:keys [output_]} data]
        (try
-         (spit fname (str (force output_) "\n") :append true)
+         (spit fname (str (force output_) "\n") :append append)
          (catch java.io.IOException e
            (if (:__spit-appender/retry? data)
              (throw e) ; Unexpected error


### PR DESCRIPTION
This PR just adds an :append param to spit-appender so spit can be configured in clobber mode instead of append mode.

```
user=> (require '[taoensso.timbre :as timbre])
nil
user=> (require '[taoensso.timbre.appenders.core :as appenders])
nil
```
Current behavior (append by default):
```
user=> (timbre/merge-config! {:appenders {:spit (appenders/spit-appender {:fname "/tmp/foo.log"})}})
<elided>
user=> (timbre/debug "first msg")
16-11-10 22:23:15 porpoise DEBUG [user:1] - first msg
nil
user=> (timbre/debug "i get appended")
16-11-10 22:23:24 porpoise DEBUG [user:1] - i get appended
nil
user=> (slurp "/tmp/foo.log")
"16-11-10 22:23:15 porpoise DEBUG [user:1] - first msg\n16-11-10 22:23:24 porpoise DEBUG [user:1] - i get appended\n"
```
New behavior (:append false uses clobber mode):
```
user=> (timbre/merge-config! {:appenders {:spit (appenders/spit-appender {:fname "/tmp/foo.log" :append false})}})
<elided>
user=> (timbre/debug "first msg")
16-11-10 22:24:00 porpoise DEBUG [user:1] - first msg
nil
user=> (timbre/debug "i clobber")
16-11-10 22:24:09 porpoise DEBUG [user:1] - i clobber
nil
user=> (slurp "/tmp/foo.log")
"16-11-10 22:24:09 porpoise DEBUG [user:1] - i clobber\n"
user=> Bye for now!
```