### PR TITLE
Do not log superfluous 'null' when logging raw cljs console output

### DIFF
--- a/src/taoensso/timbre/appenders/core.cljx
+++ b/src/taoensso/timbre/appenders/core.cljx
@@ -148,7 +148,9 @@
                       :msg_  ""
                       :?err nil))
                    ;; (<output> <raw-error> <raw-arg1> <raw-arg2> ...):
-                   args (->> (:vargs data) (cons (:?err data)) (cons output))]
+                   args (cond->>       (:vargs data)
+                          (:?err data) (cons (:?err data))
+                          true         (cons output))]
 
                (.apply logger js/console (into-array args)))
              (.call    logger js/console (force (:output_ data)))))))


### PR DESCRIPTION
When logging using the `console-appender` in `:raw-console?` mode, if there is no `:?err` in the data then there is always a  superfluous "null" written to the console before the other arguments.