### PR TITLE
Codox: Fix 'view source' links to point to cljx file in src dir for the corresponding version tag

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -82,8 +82,8 @@
   :codox
   {:language :clojure
    :source-uri
-   {#"target/classes" "https://github.com/ptaoussanis/timbre/blob/master/src/{classpath}x#L{line}"
-    #".*"             "https://github.com/ptaoussanis/timbre/blob/master/{filepath}#L{line}"}}
+   {#"target/classes" "https://github.com/ptaoussanis/timbre/blob/v{version}/src/{classpath}x#L{line}"
+    #".*"             "https://github.com/ptaoussanis/timbre/blob/v{version}/{filepath}#L{line}"}}
 
   :aliases
   {"test-all"   ["do" "clean," "cljx" "once,"

--- a/project.clj
+++ b/project.clj
@@ -81,7 +81,9 @@
 
   :codox
   {:language :clojure
-   :source-uri "https://github.com/ptaoussanis/timbre/blob/master/{filepath}#L{line}"}
+   :source-uri
+   {#"target/classes" "https://github.com/ptaoussanis/timbre/blob/master/src/{classpath}x#L{line}"
+    #".*"             "https://github.com/ptaoussanis/timbre/blob/master/{filepath}#L{line}"}}
 
   :aliases
   {"test-all"   ["do" "clean," "cljx" "once,"


### PR DESCRIPTION
Modifies the `:source-uri` for the cljx files that were pointing to a target/classes path in the github repo that do not exist. Also makes the links to point to the tag for the version from which the codox docs were generated, instead of master.

As an example, the [current documentation for `log`](http://ptaoussanis.github.io/timbre/taoensso.timbre.html#var-log) (generated from 4.7.0) is pointing to https://github.com/ptaoussanis/timbre/blob/master/target/classes/taoensso/timbre.clj#L619 when it should point to https://github.com/ptaoussanis/timbre/blob/v4.7.0/src/taoensso/timbre.cljx#L619