### PR TITLE
set docstring for with-level

### DIFF
--- a/src/taoensso/timbre.cljx
+++ b/src/taoensso/timbre.cljx
@@ -146,7 +146,9 @@
 (defn merge-config! [m] (swap-config! (fn [old] (enc/nested-merge old m))))
 
 (defn     set-level! [level] (swap-config! (fn [m] (assoc m :level level))))
-(defmacro with-level [level & body]
+(defmacro with-level
+  "set the log level dynamically for a given body"
+  [level & body]
   `(binding [*config* (assoc *config* :level ~level)] ~@body))
 
 (comment (set-level! :info) *config*)


### PR DESCRIPTION
Found myself looking this up when using `with-level`.  

Made a best attempt at an inline docstring after reading the code and the description in the timbre README. 