### PR TITLE
Provide a better default appender when running under nodejs.

### DIFF
--- a/src/taoensso/timbre.cljx
+++ b/src/taoensso/timbre.cljx
@@ -126,8 +126,9 @@
     }
 
    #+cljs
-   {;; :println (println-appender {})
-    :console (console-appender {})}})
+   {:cljs-default (if (exists? js/window)
+                    (console-appender {})
+                    (println-appender {}))}})
 
 (comment
   (set-config! example-config)


### PR DESCRIPTION
The console appender doesn't work the same way under nodejs and the println
appender seems a better default choice.