### PR TITLE
Use :error-level? instead of :error?

### DIFF
--- a/src/taoensso/timbre/appenders/core.cljx
+++ b/src/taoensso/timbre/appenders/core.cljx
@@ -54,7 +54,7 @@
          #+clj
          (let [stream
                (case stream
-                 :auto  (if (:error? data) *err* *out*)
+                 :auto  (if (:error-level? data) *err* *out*)
                  :*out* *out*
                  :*err* *err*
                  stream)]


### PR DESCRIPTION
We found `:auto` in `appenders/core.cljx` L57 is `*out*` everytime.
I think this `:error?` should be `:error-level?`.

Thanks!