### PR TITLE
Add with-extra-context macro

### DIFF
--- a/src/taoensso/timbre.cljx
+++ b/src/taoensso/timbre.cljx
@@ -328,7 +328,9 @@
       {:session \"123123\"} ; Will be merged with context defined above
       (info \"User request with session attached\")))"
 
-  [context & body] `(binding [*context* ~(merge *context* context)] ~@body))
+  [context & body]
+  `(let [old-context# *context*]
+     (binding [*context* (merge old-context# ~context)] ~@body)))
 
 (defn- vrest [v] (if (> (count v) 1) (subvec v 1) []))
 (defn- parse-vargs

--- a/src/taoensso/timbre.cljx
+++ b/src/taoensso/timbre.cljx
@@ -317,6 +317,19 @@
 
   [context & body] `(binding [*context* ~context] ~@body))
 
+(defmacro with-extra-context
+  "Executes body so that given data will be merged with previously
+  included data passed to appenders for any enclosed logging calls.
+
+  (with-context
+    {:user-name \"Stu\"} ; Will be incl. in data dispatched to appenders
+    (info \"User request\")
+    (with-extra-context
+      {:session \"123123\"} ; Will be merged with context defined above
+      (info \"User request with session attached\")))"
+
+  [context & body] `(binding [*context* ~(merge *context* context)] ~@body))
+
 (defn- vrest [v] (if (> (count v) 1) (subvec v 1) []))
 (defn- parse-vargs
   "vargs -> [?err ?meta ?msg-fmt api-vargs]"


### PR DESCRIPTION
This macro is usefull when you don't know full context at logging time.

E.g. for more detailed logging during evaluation some logical steps:

```
(let [session (get-random-session)]
  (with-context {:session "some random session"}
    (log "Catch request")
    (let [user (get-user-data)]
      (with-extra-context {:user user}
        (info "log user data with session as a scope")))))
```