### PR TITLE
Migrate from cljx to cljc.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                 *assert*             true}
 
   :dependencies
-  [[org.clojure/clojure "1.5.1"]
+  [[org.clojure/clojure "1.7.0"]
    [com.taoensso/encore "2.91.0"]
    [io.aviso/pretty     "0.1.33"]]
 
@@ -51,19 +51,11 @@
     {:dependencies [[org.clojure/clojurescript "1.9.521"]]
      :plugins
      [;; These must be in :dev, Ref. https://github.com/lynaghk/cljx/issues/47:
-      [com.keminglabs/cljx "0.6.0"]
       [lein-cljsbuild      "1.1.5"]]}]}
 
   ;; :jar-exclusions [#"\.cljx|\.DS_Store"]
   :source-paths ["src" "target/classes"]
   :test-paths   ["src" "test" "target/test-classes"]
-
-  :cljx
-  {:builds
-   [{:source-paths ["src"]        :rules :clj  :output-path "target/classes"}
-    {:source-paths ["src"]        :rules :cljs :output-path "target/classes"}
-    {:source-paths ["src" "test"] :rules :clj  :output-path "target/test-classes"}
-    {:source-paths ["src" "test"] :rules :cljs :output-path "target/test-classes"}]}
 
   :cljsbuild
   {:test-commands {"node"    ["node" :node-runner "target/tests.js"]
@@ -77,7 +69,6 @@
                       :pretty-print false}}]}
 
   :auto-clean false
-  :prep-tasks [["cljx" "once"] "javac" "compile"]
 
   :codox
   {:language :clojure
@@ -86,10 +77,10 @@
     #".*"             "https://github.com/ptaoussanis/timbre/blob/v{version}/{filepath}#L{line}"}}
 
   :aliases
-  {"test-all"   ["do" "clean," "cljx" "once,"
+  {"test-all"   ["do" "clean,"
                  "with-profile" "+1.9:+1.8:+1.7:+1.6:+1.5" "test"
                  "with-profile" "+test" "cljsbuild" "test"]
-   "build-once" ["do" "clean," "cljx" "once," "cljsbuild" "once" "main"]
+   "build-once" ["do" "clean," "cljsbuild" "once" "main"]
    "deploy-lib" ["do" "build-once," "deploy" "clojars," "install"]
    "start-dev"  ["with-profile" "+dev" "repl" ":headless"]}
 

--- a/src/taoensso/timbre.cljc
+++ b/src/taoensso/timbre.cljc
@@ -250,7 +250,7 @@
 
 (comment (ns->?level [["taoensso.*" :info]] *ns*))
 
-(defn #?(:clj may-log?) #?@(:cljs ^boolean may-log?)
+(defn #?(:clj may-log?) #?@(:cljs ( ^boolean may-log?))
   "Runtime check: would Timbre currently log at the given logging level?
     * `?ns-str` arg required to support ns filtering
     * `config`  arg required to support non-global config"

--- a/src/taoensso/timbre/appenders/core.cljc
+++ b/src/taoensso/timbre/appenders/core.cljc
@@ -2,29 +2,29 @@
   "Core Timbre appenders without any special dependency requirements.
   These can be aliased into the main Timbre ns for convenience."
   {:author "Peter Taoussanis (@ptaoussanis)"}
-  #+clj
+  #?(:clj
   (:require
    [clojure.string  :as str]
-   [taoensso.encore :as enc :refer [have have? qb]])
+   [taoensso.encore :as enc :refer [have have? qb]]))
 
-  #+cljs
+  #?(:cljs
   (:require
    [clojure.string  :as str]
-   [taoensso.encore :as enc :refer-macros [have have?]]))
+   [taoensso.encore :as enc :refer-macros [have have?]])))
 
 ;; TODO Add a simple official rolling spit appender?
 
 ;;;; Println appender (clj & cljs)
 
-#+clj (enc/declare-remote taoensso.timbre/default-out
-                          taoensso.timbre/default-err)
-#+clj (alias 'timbre 'taoensso.timbre)
+#?(:clj (enc/declare-remote taoensso.timbre/default-out
+                          taoensso.timbre/default-err))
+#?(:clj (alias 'timbre 'taoensso.timbre))
 
-#+clj
+#?(:clj
 (def ^:private ^:const system-newline
-  (System/getProperty "line.separator"))
+  (System/getProperty "line.separator")))
 
-#+clj (defn- atomic-println [x] (print (str x system-newline)) (flush))
+#?(:clj (defn- atomic-println [x] (print (str x system-newline)) (flush)))
 
 (defn println-appender
   "Returns a simple `println` appender for Clojure/Script.
@@ -35,12 +35,12 @@
   ;; Unfortunately no easy way to check if *print-fn* is set. Metadata on the
   ;; default throwing fn would be nice...
 
-  [& #+clj [{:keys [stream] :or {stream :auto}}] #+cljs [_opts]]
-  (let [#+clj stream
-        #+clj (case stream
+  [& #?(:clj [{:keys [stream] :or {stream :auto}}]) #?(:cljs [_opts])]
+  (let [#?(:clj stream)
+        #?(:clj (case stream
                 :std-err timbre/default-err
                 :std-out timbre/default-out
-                stream)]
+                stream))]
 
     {:enabled?   true
      :async?     false
@@ -50,8 +50,8 @@
      :fn
      (fn [data]
        (let [{:keys [output_]} data]
-         #+cljs (println (force output_))
-         #+clj
+         #?(:cljs (println (force output_)))
+         #?(:clj
          (let [stream
                (case stream
                  :auto  (if (:error-level? data) *err* *out*)
@@ -60,14 +60,14 @@
                  stream)]
 
            (binding [*out* stream]
-             #+clj  (atomic-println (force output_))
-             #+cljs (println        (force output_))))))}))
+             #?(:clj  (atomic-println (force output_)))
+             #?(:cljs (println        (force output_))))))))}))
 
 (comment (println-appender))
 
 ;;;; Spit appender (clj only)
 
-#+clj
+#?(:clj
 (defn spit-appender
   "Returns a simple `spit` file appender for Clojure."
   [& [{:keys [fname append?]
@@ -91,7 +91,7 @@
                    dir  (.getParentFile (.getCanonicalFile file))]
 
                (when-not (.exists dir) (.mkdirs dir))
-               (self (assoc data :__spit-appender/retry? true))))))))})
+               (self (assoc data :__spit-appender/retry? true))))))))}))
 
 (comment
   (spit-appender)
@@ -100,7 +100,7 @@
 
 ;;;; js/console appender (cljs only)
 
-#+cljs
+#?(:cljs
 (defn console-appender
   "Returns a simple js/console appender for ClojureScript.
 
@@ -158,10 +158,10 @@
                (.apply logger js/console (into-array args)))
              (.call    logger js/console (force (:output_ data)))))))
 
-     (fn [data] nil))})
+     (fn [data] nil))}))
 
 (comment (console-appender))
 
 ;;;; Deprecated
 
-#+cljs (def console-?appender "DEPRECATED" console-appender)
+#?(:cljs (def console-?appender "DEPRECATED" console-appender))


### PR DESCRIPTION
Started migrating manually, then wrote this: https://github.com/anthonygalea/cljx/blob/master/cljx.el#L31

The only thing I corrected by hand was changing to the splicing conditional around the `^boolean` type hint. i.e. after the script ran I rewrote:
```
#?(:cljs ^boolean) may-log?
```
to:
```
#?@(:cljs ^boolean may-log?)
```

Not sure how you usually go about testing. Tried a couple of calls and I see the same behaviour I see with `4.10.0`:
```clojure
(ns playground.timbre
  (:require [taoensso.timbre :as timbre
             :refer [log  trace  debug  info  warn  error  fatal  report
                     logf tracef debugf infof warnf errorf fatalf reportf
                     spy get-env]]))

(info "This will print")

(spy :info (* 5 4 3 2 1))

(defn my-mult [x y]
  (info "Lexical env:" (get-env))
  (* x y))

(my-mult 4 8)
```