### PR TITLE
Upgrade raven-clj to get the sentry_timestamp bugfix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
      [cheshire                "5.6.3"]
      [ymilky/franzy           "0.0.1"]
      [com.newrelic.agent.java/newrelic-agent "3.31.1"]
-     [raven-clj               "1.5.0"]]}
+     [raven-clj               "1.6.0-alpha4"]]}
 
    :dev
    [:1.9 :test :server-jvm


### PR DESCRIPTION
Recently a bug in raven-clj was discovered which resulted in all sentry events being rejected for invalid timestamp. The fix has already been released in raven-clj 1.6.0-alpha4. See this [PR](https://github.com/sethtrain/raven-clj/pull/28) and this [sentry support forum post](https://forum.sentry.io/t/string-formatted-timestamp-in-header-no-longer-accepted-by-api-breaking-clojure-raven-library/8383) for more details.

I would like to upgrade the version of raven-clj used by timbre so that the sentry appender will continue to work.

PS: I was unable to run unit tests with this change since I could not figure out how to get the android runtime set up.