### PR TITLE
Fix #329 spit-appender deadlock

### DIFF
--- a/src/taoensso/timbre/appenders/core.cljc
+++ b/src/taoensso/timbre/appenders/core.cljc
@@ -87,22 +87,22 @@
       (let [lock (Object.)]
         (fn self [data]
           (let [{:keys [output_]} data]
-            (try
-              (when locking? (monitor-enter lock)) ; For thread safety, Ref. #251
-              (with-open [^java.io.BufferedWriter w (jio/writer fname :append append?)]
-                (.write   w ^String (force output_))
-                (.newLine w))
+            (let [forced (force output_)]
+              (try
+                (when locking? (monitor-enter lock)) ; For thread safety, Ref. #251
+                (with-open [^java.io.BufferedWriter w (jio/writer fname :append append?)]
+                  (.write   w ^String forced)
+                  (.newLine w))
 
-              (catch java.io.IOException e
-                (if (:spit-appender/retry? data)
-                  (throw e) ; Unexpected error
-                  (do
-                    (jio/make-parents fname)
-                    (self (assoc data :spit-appender/retry? true)))))
-
-              (finally
-                (when locking?
-                  (monitor-exit lock)))))))}))
+                (catch java.io.IOException e
+                  (if (:spit-appender/retry? data)
+                    (throw e) ; Unexpected error
+                    (do
+                      (jio/make-parents fname)
+                      (self (assoc data :spit-appender/retry? true)))))
+                (finally
+                  (when locking?
+                    (monitor-exit lock))))))))}))
 
 (comment
   (spit-appender)


### PR DESCRIPTION
In spit-appender, force the output before acquiring a lock in
case the forced code tries to acquire the same spit-appender lock
from a different thread.

This is code that'll deadlock on the current production version:

```clojure
(require '[taoensso.timbre :as timbre])
(require '[taoensso.timbre.appenders.core :as appenders])
(timbre/swap-config! merge {:appenders {:spit (appenders/spit-appender {:fname "/tmp/log.log"})}})
(timbre/info "root" (pmap #(timbre/info "num" %) (range 10)))
```