### PR TITLE
default-output-fn: Let :timestamp_ be optional.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.taoensso/timbre "5.1.0"
+(defproject com.taoensso/timbre "5.1.1"
   :author "Peter Taoussanis <https://www.taoensso.com>"
   :description "Pure Clojure/Script logging library"
   :url "https://github.com/ptaoussanis/timbre"

--- a/src/taoensso/timbre.cljc
+++ b/src/taoensso/timbre.cljc
@@ -43,8 +43,7 @@
          {:keys [level ?err #_vargs msg_ ?ns-str ?file hostname_
                  timestamp_ ?line]} data]
      (str
-       (force timestamp_)
-       " "
+       (let [ts (force timestamp_)] (when ts (str ts " ")))
        #?(:clj (force hostname_))  #?(:clj " ")
        (str/upper-case (name level))  " "
        "[" (or ?ns-str ?file "?") ":" (or ?line "?") "] - "


### PR DESCRIPTION
E.g. timestamps are huge in the JS console, and often not very interesting there.