### PR TITLE
Fix spit-appender lock for graalvm

### DIFF
--- a/src/taoensso/timbre/appenders/core.cljc
+++ b/src/taoensso/timbre/appenders/core.cljc
@@ -97,13 +97,14 @@
 
      (have? enc/nblank-str? fname)
 
-     {:enabled? true
-      :fn
-      (fn self [data]
-        (if locking?
-          (locking (Object.)
-            (write-to-file data fname append? self))
-          (write-to-file data fname append? self)))}))
+     (let [lock (Object.)]
+       {:enabled? true
+        :fn
+        (fn self [data]
+          (if locking?
+            (locking lock
+              (write-to-file data fname append? self))
+            (write-to-file data fname append? self)))})))
 
 (comment
   (spit-appender)


### PR DESCRIPTION
When compiling a app using `spit-appender`, graalvm complains about a lock from monitor-enter/exit that does not matches.
Log: https://pastebin.com/g9wqxqbv

This looks the same issue `clojure.core` had on its defmacro `locking` on [CLJ-1472](https://github.com/clojure/clojure/commit/f5403e9c666f3281fdb880cb2c21303c273eed2d#), since the macro is fixed, we can use it instead of manually calling `monitor-enter/exit`

Thank you for the help on this @borkdude