### PR TITLE
Better formatting of javascript errors

### DIFF
--- a/src/taoensso/timbre.cljc
+++ b/src/taoensso/timbre.cljc
@@ -896,7 +896,11 @@
 (defn stacktrace
   ([err     ] (stacktrace err nil))
   ([err opts]
-   #?(:cljs (str err enc/system-newline (.-stack err)) ; TODO Alternatives?
+   #?(:cljs
+      ;; TODO Alternatives?
+      (str err
+           (when-let [s (.-stack err)]
+             (str enc/system-newline s)))
       :clj
       (let [stacktrace-fonts ; {:stacktrace-fonts nil->{}}
             (if-let [e (find opts :stacktrace-fonts)]

--- a/src/taoensso/timbre.cljc
+++ b/src/taoensso/timbre.cljc
@@ -896,7 +896,7 @@
 (defn stacktrace
   ([err     ] (stacktrace err nil))
   ([err opts]
-   #?(:cljs (or (.-stack err) (str err)) ; TODO Alternatives?
+   #?(:cljs (str err enc/system-newline (.-stack err)) ; TODO Alternatives?
       :clj
       (let [stacktrace-fonts ; {:stacktrace-fonts nil->{}}
             (if-let [e (find opts :stacktrace-fonts)]


### PR DESCRIPTION
I think in javascript land, we want to show the stringified error (which contains the type of error and err.message, both important pieces of info) as well as the stacktrace if it exists.