### PR TITLE
Bump encore version to address ptaoussanis/encore#55.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                 *assert*             true}
 
   :dependencies
-  [[com.taoensso/encore "3.12.1"]
+  [[com.taoensso/encore "3.20.0"]
    [io.aviso/pretty     "0.1.37"]]
 
   :plugins


### PR DESCRIPTION
Hi,

I've spent better part of the day trying to understand strange `ns-filter` behavior only to discover it was an already fixed bug in encore's `:deny`-only compile-str-filter, ptaoussanis/encore#55.

I've skimmed through encore's commit history between 3.12 and 3.20 and -- apart from fixing the issue -- there don't seem to be changes that would break anything else in timbre.

Therefore, I suggest bumping encore dep version to prevent other unsuspecting souls from yak shaving their time away. :)

