### PR TITLE
Make `callsite-id` in `log!` macro deterministic for Clojure

### DIFF
--- a/src/taoensso/timbre.cljc
+++ b/src/taoensso/timbre.cljc
@@ -691,6 +691,14 @@
 
 (defn- fline [and-form] (:line (meta and-form)))
 
+
+#?(:clj
+   (let [rand ^java.util.Random (java.util.Random. 715873)]
+     (defn deterministic-rand []
+       (.nextDouble rand)))
+   :cljs
+   (def deterministic-rand rand))
+
 (defmacro log! ; Public wrapper around `-log!`
   "Core low-level log macro. Useful for tooling/library authors, etc.
 
@@ -726,7 +734,7 @@
             ;; `slf4j-timbre`, etc.):
             callsite-id
             (hash [level msg-type args ; Unevaluated args (arg forms)
-                   ?ns-str ?file ?line (rand)])
+                   ?ns-str ?file ?line (deterministic-rand)])
 
             vargs-form
             (if (symbol? args)


### PR DESCRIPTION
Since the non-deterministic `rand` was used as part of generating `callsite-id` in the `log!` macro at compile time, the compiler would produce non-deterministic bytecode as a result. This thwarts reproducible builds.

Instead, use a RNG with a fixed seed. Unfortunately, both the JS standard library and Google Closure's library don't seem to provide a similar facility, so it's only implemented for Clojure.