### PR TITLE
Remove `println` on core ns load

### DIFF
--- a/src/taoensso/timbre.cljc
+++ b/src/taoensso/timbre.cljc
@@ -1218,9 +1218,7 @@
               :prop    "taoensso.timbre.config.edn"
               :res     "taoensso.timbre.config.edn"
               :res-env "taoensso.timbre.config-resource"})]
-
-       (println (str "Loading initial Timbre config from: " source))
-       config)))
+       (assoc config :source source))))
 
 ;;;; Deprecated
 


### PR DESCRIPTION
Libraries printing information without control are often a nuisance. Instead of printing the source of `*config*`, it is kept in the config itself.